### PR TITLE
Add an API endpoint to persist block styles to an option

### DIFF
--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -137,7 +137,7 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 		}
 
 		$raw_settings = json_decode( $body );
-		if ( ! $raw_settings ) {
+		if ( ! is_array( $raw_settings ) ) {
 			return new WP_Error( 'rest_invalid_json', __( 'The data submitted was malformed.' ), array( 'status' => 400 ) );
 		}
 

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -65,20 +65,20 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		return get_option( 'wc-cbs-styles', array(
-			array(
-				'name'  => 'blue',
-				'id'    => 1,
-				'label' => __( 'Blue', 'wc-custom-block-styles' ),
-				'block' => 'core/paragraph',
-			),
-			array(
-				'name'  => 'red',
-				'id'    => 2,
-				'label' => __( 'Red', 'wc-custom-block-styles' ),
-				'block' => 'core/paragraph',
-			),
-		) );
+		$settings = get_option( 'wc-cbs-styles', array() );
+		$response = $this->prepare_item_for_response( $settings, $request );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Prepares the settings for the REST response.
+	 *
+	 * @param array           $settings WordPress representation of the settings.
+	 * @param WP_REST_Request $request  Request object.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function prepare_item_for_response( $settings, $request ) {
+		return rest_sanitize_value_from_schema( $settings, $this->get_item_schema() );
 	}
 
 	/**

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -2,7 +2,7 @@
 /**
  * REST API Settings Controller
  *
- * Handles requests to /wc-cbs/v1/settings
+ * Handles requests to /wc-cbs/v1/styles
  *
  * @package WC Custom Block Styles
  */
@@ -29,7 +29,7 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = '/settings';
+	protected $rest_base = 'styles';
 
 	/**
 	 * Registers the routes for the objects of the controller.

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -59,8 +59,7 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
-		// @todo Real security 😬
-		return true || current_user_can( 'edit_posts' );
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -70,8 +69,7 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|bool True if the request has access to update the item, WP_Error object otherwise.
 	 */
 	public function update_item_permissions_check( $request ) {
-		// @todo Real security 😬
-		return true || current_user_can( 'edit_posts' );
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -94,6 +94,10 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 		$current_settings = get_option( 'wc-cbs-styles', array() );
 		$settings = $this->prepare_item_for_database( $request );
 
+		if ( is_wp_error( $settings ) ) {
+			return rest_ensure_response( $settings );
+		}
+
 		if ( $current_settings !== $settings ) {
 			$result = update_option( 'wc-cbs-styles', $settings, false );
 

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -67,4 +67,40 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	public function get_items( $request ) {
 		return get_option( 'wc-cbs-styles', array() );
 	}
+
+	/**
+	 * Get the settings schema, conforming to JSON Schema
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema' => 'http://json-schema.org/draft-04/schema#',
+			'title'   => 'wc_cbs_settings',
+			'type'    => 'array',
+			'items'   => array(
+				'type'       => 'object',
+				'context'    => array( 'view' ),
+				'properties' => array(
+					'id' => array(
+						'type'        => 'string',
+						'description' => __( 'A numeric ID unique to the style.', 'wc-custom-block-styles' ),
+					),
+					'label' => array(
+						'type'        => 'string',
+						'description' => __( 'The human-readable name for this style.', 'wc-custom-block-styles' ),
+					),
+					'name' => array(
+						'type'        => 'string',
+						'description' => __( 'The CSS class added to the block, generated from the label.', 'wc-custom-block-styles' ),
+					),
+					'block' => array(
+						'type'        => 'string',
+						'description' => __( 'The block name which should use this style.', 'wc-custom-block-styles' ),
+					),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -129,12 +129,12 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	protected function prepare_item_for_database( $request ) {
 		$body = $request->get_body();
 		if ( ! $body ) {
-			return new WP_Error( 'rest_no_data', __( 'No data.' ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_no_data', __( 'No data was submitted.' ), array( 'status' => 400 ) );
 		}
 
 		$raw_settings = json_decode( $body );
 		if ( ! $raw_settings ) {
-			return new WP_Error( 'rest_invalid_json', __( 'Invalid JSON.' ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_invalid_json', __( 'The data submitted was malformed.' ), array( 'status' => 400 ) );
 		}
 
 		return rest_sanitize_value_from_schema( $raw_settings, $this->get_item_schema() );

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -96,20 +96,32 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 				'context'    => array( 'view' ),
 				'properties' => array(
 					'id' => array(
-						'type'        => 'string',
+						'type'        => 'integer',
 						'description' => __( 'A numeric ID unique to the style.', 'wc-custom-block-styles' ),
+						'arg_options' => array(
+							'required' => true,
+						),
 					),
 					'label' => array(
 						'type'        => 'string',
 						'description' => __( 'The human-readable name for this style.', 'wc-custom-block-styles' ),
+						'arg_options' => array(
+							'required' => true,
+						),
 					),
 					'name' => array(
 						'type'        => 'string',
-						'description' => __( 'The CSS class added to the block, generated from the label.', 'wc-custom-block-styles' ),
+						'description' => __( 'The CSS class added to the block.', 'wc-custom-block-styles' ),
+						'arg_options' => array(
+							'required' => true,
+						),
 					),
 					'block' => array(
 						'type'        => 'string',
 						'description' => __( 'The block name which should use this style.', 'wc-custom-block-styles' ),
+						'arg_options' => array(
+							'required' => true,
+						),
 					),
 				),
 			),

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -65,7 +65,20 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		return get_option( 'wc-cbs-styles', array() );
+		return get_option( 'wc-cbs-styles', array(
+			array(
+				'name'  => 'blue',
+				'id'    => 1,
+				'label' => __( 'Blue', 'wc-custom-block-styles' ),
+				'block' => 'core/paragraph',
+			),
+			array(
+				'name'  => 'red',
+				'id'    => 2,
+				'label' => __( 'Red', 'wc-custom-block-styles' ),
+				'block' => 'core/paragraph',
+			),
+		) );
 	}
 
 	/**

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -38,7 +38,7 @@ class WC_CBS_Settings_Controller extends WP_REST_Controller {
 		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
 			// Here we register the readable endpoint for collections.
 			array(
-				'methods'   => 'GET',
+				'methods'   => WP_REST_Server::READABLE,
 				'callback'  => array( $this, 'get_items' ),
 				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			),

--- a/api/class-wc-cbs-settings-controller.php
+++ b/api/class-wc-cbs-settings-controller.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * REST API Settings Controller
+ *
+ * Handles requests to /wc-cbs/v1/settings
+ *
+ * @package WC Custom Block Styles
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Controller
+ *
+ * @package WC Custom Block Styles
+ * @extends WP_REST_Controller
+ */
+class WC_CBS_Settings_Controller extends WP_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-cbs/v1';
+
+	/**
+	 * The base of this controller's route.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = '/settings';
+
+	/**
+	 * Registers the routes for the objects of the controller.
+	 */
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+			// Here we register the readable endpoint for collections.
+			array(
+				'methods'   => 'GET',
+				'callback'  => array( $this, 'get_items' ),
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
+			),
+			// Register our schema callback.
+			'schema' => array( $this, 'get_item_schema' ),
+		) );
+	}
+
+	/**
+	 * Checks if a given request has access to get the settings.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|bool True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		// @todo Real security 😬
+		return true || current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Retrieves a collection of items.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		return get_option( 'wc-cbs-styles', array() );
+	}
+}

--- a/api/class-wc-cbs-styles-controller.php
+++ b/api/class-wc-cbs-styles-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST API Settings Controller
+ * REST API Style Settings Controller
  *
  * Handles requests to /wc-cbs/v1/styles
  *
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @package WC Custom Block Styles
  * @extends WP_REST_Controller
  */
-class WC_CBS_Settings_Controller extends WP_REST_Controller {
+class WC_CBS_Styles_Controller extends WP_REST_Controller {
 
 	/**
 	 * Endpoint namespace.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9053,10 +9053,22 @@
         "strip-indent": "^2.0.0"
       }
     },
+    "redux-multi": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
+      "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI=",
+      "dev": true
+    },
     "reflect.ownkeys": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
       "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
+    },
+    "refx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/refx/-/refx-3.1.1.tgz",
+      "integrity": "sha512-lwN27W5iYyagpCxxYDYDl0IIiKh0Vgi3wvafqfthbzTfBgLOYAstcftp+G2X612xVaB8rhn5wDxd4er4KEeb8A==",
       "dev": true
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "license": "GPL-2.0-or-later",
   "devDependencies": {
     "@wordpress/eslint-plugin": "2.1.0",
-    "@wordpress/scripts": "3.1.0"
+    "@wordpress/scripts": "3.1.0",
+    "redux-multi": "0.1.12",
+    "refx": "3.1.1"
   },
   "engines": {
     "node": "10.15.3",

--- a/src/sidebar/controls/style-control.js
+++ b/src/sidebar/controls/style-control.js
@@ -13,7 +13,7 @@ import { withDispatch } from '@wordpress/data';
 import { getClass } from '../../utils';
 
 const StyleControl = ( { onChange, onRemove, style } ) => {
-	const { id, label } = style;
+	const { id, label, block } = style;
 	return (
 		<fieldset>
 			<legend className="screen-reader-text">{ label }</legend>
@@ -22,7 +22,7 @@ const StyleControl = ( { onChange, onRemove, style } ) => {
 					<TextControl
 						label={ __( 'Style Name', 'wc-custom-block-styles' ) }
 						value={ label }
-						onChange={ partial( onChange, id ) }
+						onChange={ partial( onChange, id, block ) }
 					/>
 					<TextControl
 						label={ __( 'CSS Class', 'wc-custom-block-styles' ) }
@@ -46,8 +46,9 @@ export default compose( [
 		const { deleteStyle, updateStyle } = dispatch( 'wc-custom-block-style' );
 
 		return {
-			onChange( id, value ) {
+			onChange( id, block, value ) {
 				updateStyle( id, {
+					block,
 					label: value,
 				} );
 			},

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,0 +1,24 @@
+export default {
+	addStyle( block, style ) {
+		return {
+			type: 'ADD_STYLE',
+			block,
+			style,
+		};
+	},
+
+	updateStyle( id, style ) {
+		return {
+			type: 'UPDATE_STYLE',
+			id,
+			style,
+		};
+	},
+
+	deleteStyle( id ) {
+		return {
+			type: 'DELETE_STYLE',
+			id,
+		};
+	},
+};

--- a/src/store/effects.js
+++ b/src/store/effects.js
@@ -1,0 +1,27 @@
+/**
+ * External Dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+function saveSettings( action, { getState } ) {
+	const state = getState();
+	apiFetch( {
+		path: '/wc-cbs/v1/settings',
+		data: state,
+		method: 'POST',
+	} ).then(
+		/* We don't need to do anything… */
+	).catch( () => {
+		/* We need to handle the error. */
+	} );
+}
+
+export default {
+	ADD_STYLE: debounce( saveSettings, 250 ),
+	UPDATE_STYLE: debounce( saveSettings, 250 ),
+};

--- a/src/store/effects.js
+++ b/src/store/effects.js
@@ -13,7 +13,7 @@ import { dispatch } from '@wordpress/data';
 function saveSettings( action, { getState } ) {
 	const state = getState();
 	apiFetch( {
-		path: '/wc-cbs/v1/settings',
+		path: '/wc-cbs/v1/styles',
 		data: state,
 		method: 'POST',
 	} )

--- a/src/store/effects.js
+++ b/src/store/effects.js
@@ -33,5 +33,6 @@ function saveSettings( action, { getState } ) {
 
 export default {
 	ADD_STYLE: debounce( saveSettings, 250 ),
+	DELETE_STYLE: debounce( saveSettings, 250 ),
 	UPDATE_STYLE: debounce( saveSettings, 250 ),
 };

--- a/src/store/effects.js
+++ b/src/store/effects.js
@@ -6,7 +6,9 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { dispatch } from '@wordpress/data';
 
 function saveSettings( action, { getState } ) {
 	const state = getState();
@@ -14,11 +16,19 @@ function saveSettings( action, { getState } ) {
 		path: '/wc-cbs/v1/settings',
 		data: state,
 		method: 'POST',
-	} ).then(
+	} )
 		/* We don't need to do anything… */
-	).catch( () => {
-		/* We need to handle the error. */
-	} );
+		.then()
+		.catch( ( error ) => {
+			/* We need to handle the error. */
+			const message = sprintf(
+				__( 'Error saving block styles: %s', 'wc-custom-block-styles' ),
+				error.message
+			);
+			dispatch( 'core/notices' ).createNotice( 'warning', message, {
+				isDismissible: true,
+			} );
+		} );
 }
 
 export default {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { groupBy, max } from 'lodash';
+import { max } from 'lodash';
 
 /**
  * WordPress Dependencies
@@ -11,8 +11,10 @@ import { registerStore } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import actions from './actions';
 import applyMiddlewares from './middleware';
 import { getClass } from '../utils';
+import selectors from './selectors';
 
 /**
  * State structure is an array of "style" objects
@@ -54,40 +56,8 @@ const store = registerStore( 'wc-custom-block-style', {
 		return state;
 	},
 
-	actions: {
-		addStyle( block, style ) {
-			return {
-				type: 'ADD_STYLE',
-				block,
-				style,
-			};
-		},
-
-		updateStyle( id, style ) {
-			return {
-				type: 'UPDATE_STYLE',
-				id,
-				style,
-			};
-		},
-
-		deleteStyle( id ) {
-			return {
-				type: 'DELETE_STYLE',
-				id,
-			};
-		},
-	},
-
-	selectors: {
-		getStyles( state ) {
-			return state;
-		},
-
-		getStylesByBlockType( state ) {
-			return groupBy( state, 'block' );
-		},
-	},
+	actions,
+	selectors,
 } );
 applyMiddlewares( store );
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,7 +11,8 @@ import { registerStore } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getClass } from './utils';
+import applyMiddlewares from './middleware';
+import { getClass } from '../utils';
 
 /**
  * State structure is an array of "style" objects
@@ -88,5 +89,6 @@ const store = registerStore( 'wc-custom-block-style', {
 		},
 	},
 } );
+applyMiddlewares( store );
 
 export default store;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -23,7 +23,7 @@ import selectors from './selectors';
  *   style.label - the human-readable name for this style
  *   style.name  - the CSS class added to the block, generated from the label
  */
-const DEFAULT_STATE = CustomBlockStyle;
+const DEFAULT_STATE = Array.isArray( CustomBlockStyle ) ? CustomBlockStyle : [];
 
 let latestId = max( DEFAULT_STATE.map( ( style ) => style.id ) );
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,32 +24,7 @@ const DEFAULT_STATE = CustomBlockStyle;
 
 let latestId = max( DEFAULT_STATE.map( ( style ) => style.id ) );
 
-const actions = {
-	addStyle( block, style ) {
-		return {
-			type: 'ADD_STYLE',
-			block,
-			style,
-		};
-	},
-
-	updateStyle( id, style ) {
-		return {
-			type: 'UPDATE_STYLE',
-			id,
-			style,
-		};
-	},
-
-	deleteStyle( id ) {
-		return {
-			type: 'DELETE_STYLE',
-			id,
-		};
-	},
-};
-
-export default registerStore( 'wc-custom-block-style', {
+const store = registerStore( 'wc-custom-block-style', {
 	reducer( state = DEFAULT_STATE, action ) {
 		switch ( action.type ) {
 			case 'UPDATE_STYLE':
@@ -78,7 +53,30 @@ export default registerStore( 'wc-custom-block-style', {
 		return state;
 	},
 
-	actions,
+	actions: {
+		addStyle( block, style ) {
+			return {
+				type: 'ADD_STYLE',
+				block,
+				style,
+			};
+		},
+
+		updateStyle( id, style ) {
+			return {
+				type: 'UPDATE_STYLE',
+				id,
+				style,
+			};
+		},
+
+		deleteStyle( id ) {
+			return {
+				type: 'DELETE_STYLE',
+				id,
+			};
+		},
+	},
 
 	selectors: {
 		getStyles( state ) {
@@ -90,3 +88,5 @@ export default registerStore( 'wc-custom-block-style', {
 		},
 	},
 } );
+
+export default store;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,7 +30,7 @@ const store = registerStore( 'wc-custom-block-style', {
 			case 'UPDATE_STYLE':
 				return state.map( ( style ) => {
 					if ( action.id === style.id ) {
-						return { ...style, ...action.style, name: getClass( style ) };
+						return { ...style, ...action.style, name: getClass( action.style ) };
 					}
 					return style;
 				} );

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import refx from 'refx';
+import multi from 'redux-multi';
+import { flowRight } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import effects from './effects';
+
+/**
+ * Applies the custom middlewares used specifically in the editor module.
+ *
+ * @param {Object} store Store Object.
+ *
+ * @return {Object} Update Store Object.
+ */
+function applyMiddlewares( store ) {
+	const middlewares = [
+		refx( effects ),
+		multi,
+	];
+
+	let enhancedDispatch = () => {
+		throw new Error(
+			'Dispatching while constructing your middleware is not allowed. ' +
+			'Other middleware would not be applied to this dispatch.'
+		);
+	};
+	let chain = [];
+
+	const middlewareAPI = {
+		getState: store.getState,
+		dispatch: ( ...args ) => enhancedDispatch( ...args ),
+	};
+	chain = middlewares.map( ( middleware ) => middleware( middlewareAPI ) );
+	enhancedDispatch = flowRight( ...chain )( store.dispatch );
+
+	store.dispatch = enhancedDispatch;
+	return store;
+}
+
+export default applyMiddlewares;

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -1,0 +1,14 @@
+/**
+ * External Dependencies
+ */
+import { groupBy } from 'lodash';
+
+export default {
+	getStyles( state ) {
+		return state;
+	},
+
+	getStylesByBlockType( state ) {
+		return groupBy( state, 'block' );
+	},
+};

--- a/wc-custom-block-styles.php
+++ b/wc-custom-block-styles.php
@@ -7,16 +7,27 @@
  * Author URI: https://ryelle.codes
  * Text Domain: wc-custom-block-styles
  *
- * @package WCCustomBlockStyles
+ * @package WC Custom Block Styles
  */
 
 defined( 'ABSPATH' ) || die();
 define( 'WC_CBS_VERSION', '1.0.0' );
 
 /**
- * Enqueue assets
+ * Intialize REST API endpoint.
  */
-function wc_cbsenqueue_assets() {
+function wc_cbs_rest_api_init() {
+	require_once dirname( __FILE__ ) . '/api/class-wc-cbs-settings-controller.php';
+
+	$controller = new WC_CBS_Settings_Controller();
+	$controller->register_routes();
+}
+add_action( 'rest_api_init', 'wc_cbs_rest_api_init' );
+
+/**
+ * Enqueue assets.
+ */
+function wc_cbs_enqueue_assets() {
 	wp_enqueue_script(
 		'wc-cbs-script',
 		plugins_url( 'build/index.js', __FILE__ ),
@@ -42,4 +53,4 @@ function wc_cbsenqueue_assets() {
 
 	wp_localize_script( 'wc-cbs-script', 'CustomBlockStyle', $settings );
 }
-add_action( 'enqueue_block_editor_assets', 'wc_cbsenqueue_assets' );
+add_action( 'enqueue_block_editor_assets', 'wc_cbs_enqueue_assets' );

--- a/wc-custom-block-styles.php
+++ b/wc-custom-block-styles.php
@@ -17,9 +17,9 @@ define( 'WC_CBS_VERSION', '1.0.0' );
  * Intialize REST API endpoint.
  */
 function wc_cbs_rest_api_init() {
-	require_once dirname( __FILE__ ) . '/api/class-wc-cbs-settings-controller.php';
+	require_once dirname( __FILE__ ) . '/api/class-wc-cbs-styles-controller.php';
 
-	$controller = new WC_CBS_Settings_Controller();
+	$controller = new WC_CBS_Styles_Controller();
 	$controller->register_routes();
 }
 add_action( 'rest_api_init', 'wc_cbs_rest_api_init' );

--- a/wc-custom-block-styles.php
+++ b/wc-custom-block-styles.php
@@ -36,20 +36,7 @@ function wc_cbs_enqueue_assets() {
 		true
 	);
 
-	$settings = array(
-		array(
-			'name'  => 'blue',
-			'id'    => 1,
-			'label' => __( 'Blue', 'wc-custom-block-styles' ),
-			'block' => 'core/paragraph',
-		),
-		array(
-			'name'  => 'red',
-			'id'    => 2,
-			'label' => __( 'Red', 'wc-custom-block-styles' ),
-			'block' => 'core/paragraph',
-		),
-	);
+	$settings = get_option( 'wc-cbs-styles', array() );
 
 	wp_localize_script( 'wc-cbs-script', 'CustomBlockStyle', $settings );
 }


### PR DESCRIPTION
This creates the API endpoint `/wc-cbs/v1/styles`, which reveals the `wc-cbs-styles` option. This can only be read or updated. You need `edit_posts` permission to update this (since any editor can use block styles, this permission seemed to make sense).

This PR also updates the store to interact with the API. Each store action has a side-effect of pushing to the API, so it is always up-to-date.